### PR TITLE
Beta

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -322,7 +322,7 @@ async function CheckProxyIP(proxyIP, colo = 'CF') {
       };
       return jsonResponse;
     } else {
-      console.log(`无法通过ProxyIP ${proxyIP}:${portRemote} 访问Cloudflare，状态码: ${statusCode}`);
+      console.log(`无法通过ProxyIP ${proxyIP}:${portRemote} 访问Cloudflare，状态码: ${statusCode} 响应内容: ${responseText}`);
       return {
         success: false,
         proxyIP: proxyIP,

--- a/_worker.js
+++ b/_worker.js
@@ -237,19 +237,102 @@ async function CheckProxyIP(proxyIP, colo = 'CF') {
     portRemote = parseInt(proxyIP.split(':')[1]);
     proxyIP = proxyIP.split(':')[0];
   }
+
+  const tcpSocket = connect({
+    hostname: proxyIP,
+    port: portRemote,
+  });
+
   try {
-    const isSuccessful = await 验证反代IP(proxyIP, portRemote);
-    // 构建JSON响应
-    const jsonResponse = {
-      success: isSuccessful[0],
-      proxyIP: proxyIP,
-      portRemote: portRemote,
-      colo: colo,
-      responseTime: isSuccessful[2] ? isSuccessful[2] : -1,
-      message: isSuccessful[1],
-      timestamp: new Date().toISOString(),
-    };
-    return jsonResponse;
+    // 构建HTTP GET请求
+    const httpRequest =
+      "GET /cdn-cgi/trace HTTP/1.1\r\n" +
+      "Host: speed.cloudflare.com\r\n" +
+      "User-Agent: CheckProxyIP/cmliu\r\n" +
+      "Connection: close\r\n\r\n";
+
+    // 发送HTTP请求
+    const writer = tcpSocket.writable.getWriter();
+    await writer.write(new TextEncoder().encode(httpRequest));
+    writer.releaseLock();
+
+    // 读取HTTP响应
+    const reader = tcpSocket.readable.getReader();
+    let responseData = new Uint8Array(0);
+    let receivedData = false;
+
+    // 读取所有可用数据
+    while (true) {
+      const { value, done } = await Promise.race([
+        reader.read(),
+        new Promise(resolve => setTimeout(() => resolve({ done: true }), 5000)) // 5秒超时
+      ]);
+
+      if (done) break;
+      if (value) {
+        receivedData = true;
+        // 合并数据
+        const newData = new Uint8Array(responseData.length + value.length);
+        newData.set(responseData);
+        newData.set(value, responseData.length);
+        responseData = newData;
+
+        // 检查是否接收到完整响应
+        const responseText = new TextDecoder().decode(responseData);
+        if (responseText.includes("\r\n\r\n") &&
+          (responseText.includes("Connection: close") || responseText.includes("content-length"))) {
+          break;
+        }
+      }
+    }
+    reader.releaseLock();
+
+    // 解析HTTP响应
+    const responseText = new TextDecoder().decode(responseData);
+    const statusMatch = responseText.match(/^HTTP\/\d\.\d\s+(\d+)/i);
+    const statusCode = statusMatch ? parseInt(statusMatch[1]) : null;
+
+    // 判断是否成功
+    function isValidProxyResponse(responseText, responseData) {
+      const statusMatch = responseText.match(/^HTTP\/\d\.\d\s+(\d+)/i);
+      const statusCode = statusMatch ? parseInt(statusMatch[1]) : null;
+      const looksLikeCloudflare = responseText.includes("cloudflare");
+      const isExpectedError = responseText.includes("plain HTTP request") || responseText.includes("400 Bad Request");
+      const hasBody = responseData.length > 100;
+
+      return statusCode !== null && looksLikeCloudflare && isExpectedError && hasBody;
+    }
+    // 关闭连接
+    await tcpSocket.close();
+
+    const isSuccessful = isValidProxyResponse(responseText, responseData);
+    if (isSuccessful) {
+      console.log(`成功通过ProxyIP ${proxyIP}:${portRemote} 连接到Cloudflare，状态码: ${statusCode}`);
+      const tls握手 = await 验证反代IP(proxyIP, portRemote);
+
+      // 构建JSON响应
+      const jsonResponse = {
+        success: tls握手[0],
+        proxyIP: proxyIP,
+        portRemote: portRemote,
+        colo: colo,
+        responseTime: tls握手[2] ? tls握手[2] : -1,
+        message: tls握手[1],
+        timestamp: new Date().toISOString(),
+      };
+      return jsonResponse;
+    } else {
+      console.log(`无法通过ProxyIP ${proxyIP}:${portRemote} 访问Cloudflare，状态码: ${statusCode}`);
+      return {
+        success: false,
+        proxyIP: proxyIP,
+        portRemote: portRemote,
+        colo: colo,
+        responseTime: -1,
+        message: "无法通过ProxyIP访问Cloudflare",
+        timestamp: new Date().toISOString()
+      };
+    }
   } catch (error) {
     // 连接失败，返回失败的JSON
     return {

--- a/_worker.js
+++ b/_worker.js
@@ -296,8 +296,8 @@ async function CheckProxyIP(proxyIP, colo = 'CF') {
     function isValidProxyResponse(responseText, responseData) {
       const statusMatch = responseText.match(/^HTTP\/\d\.\d\s+(\d+)/i);
       const statusCode = statusMatch ? parseInt(statusMatch[1]) : null;
-      const looksLikeCloudflare = responseText.includes("cloudflare");
-      const isExpectedError = responseText.includes("plain HTTP request") || responseText.includes("400 Bad Request");
+      const looksLikeCloudflare = responseText.includes("cloudflare") && responseText.includes("CF-RAY");
+      const isExpectedError = responseText.includes("The plain HTTP request was sent to HTTPS port") && responseText.includes("400 Bad Request");
       const hasBody = responseData.length > 100;
 
       return statusCode !== null && looksLikeCloudflare && isExpectedError && hasBody;

--- a/_worker.js
+++ b/_worker.js
@@ -307,7 +307,7 @@ async function CheckProxyIP(proxyIP, colo = 'CF') {
 
     const isSuccessful = isValidProxyResponse(responseText, responseData);
     if (isSuccessful) {
-      console.log(`成功通过ProxyIP ${proxyIP}:${portRemote} 连接到Cloudflare，状态码: ${statusCode}`);
+      console.log(`成功通过ProxyIP ${proxyIP}:${portRemote} 连接到Cloudflare，状态码: ${statusCode} 响应内容: ${responseText}`);
       const tls握手 = await 验证反代IP(proxyIP, portRemote);
 
       // 构建JSON响应


### PR DESCRIPTION
这次 Pull Request 主要是把 `_worker.js` 里的 **代理 IP 检测逻辑** 做了重构，用更底层的 HTTP 请求方式直接去访问 Cloudflare，从而让代理验证更准确，出错时的处理也更清晰。  

具体改动包括：  
- 建立 TCP 连接 → 手动构造并发送 HTTP 请求 → 解析返回结果 → 更新验证成功的标准和返回的 JSON 格式。  

### 🚀 代理验证的改进
- 把之前的 “验证反代IP” 检查，改成直接用 TCP 建立连接并向 `speed.cloudflare.com` 发送原始 HTTP GET 请求，这样能更可靠地判断代理是否正常。  
- 增加了更细致的响应解析：提取状态码、检查 Cloudflare 特有的响应头和错误信息，用来判断代理是否真的可用。  

### ⚠️ 错误处理和结果反馈
- 错误处理更完善：能区分成功和失败的代理连接，记录更详细的日志，并且统一返回标准化的 JSON。  
- JSON 返回结果里新增了 HTTP 请求和后续 TLS 握手检查的结果，包括更清晰的提示信息和响应时间。  
